### PR TITLE
ignore empty lines before stylelint commands like stylelint-disable-next-line

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ module.exports = {
     ],
     'comment-empty-line-before': [
       'always',
-      { except: ['first-nested'] },
+      { ignore: ['stylelint-commands'], except: ['first-nested'] },
     ],
     'block-opening-brace-space-before': 'always',
     'declaration-colon-space-after': 'always',


### PR DESCRIPTION
Обычные комментарии можно писать в несколько строк, совмещая их в одну группу:
```css
/**
 * Первая строка
 * Вторая строка
 */
```

Но команды линтера по типу `stylelint-disable-next-line` не работают внутри таких многострочных комментариев (потому что следующая строка является закрывающей комментарий, а не нашим проблемным кодом)

Поэтому единственным вариантом прокомментировать команду линтера является использование двух комментариев:

```css
/* Я отключил это правило, потому что так надо */
/* stylelint-disable-next-line some-good-rule */
```

или

```css
/**
 * Отключить правило нужно
 * Но в то же время это неправильно
 */
 /* stylelint-disable-next-line some-good-rule */
```

Но текущие правила линтера не позволяют так сделать. Данный MR исправляет эту проблему