### PR TITLE
dependabot: use 'groups'; set schedule to weekly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,18 +3,30 @@ updates:
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
     allow:
       - dependency-type: "direct"
+    groups:
+      jest:
+        patterns:
+          - 'jest'
+          - 'jest-*'
+          - '@types/jest'
+          - 'ts-jest'
+      stylelint:
+        patterns:
+          - 'stylelint'
+          - 'stylelint-*'
     reviewers:
       - "VKCOM/vk-sec"
       - "VKCOM/frontend-core"
+
   - package-ecosystem: "github-actions"
     # Workflow files stored in the
     # default location of `.github/workflows`
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
     reviewers:
       - "VKCOM/vk-sec"
       - "VKCOM/frontend-core"


### PR DESCRIPTION
## Ссылки

- [Configuration options for the dependabot.yml file • groups](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#groups)