### PR TITLE
feat: disallow type and universal selectors

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,6 +9,8 @@ module.exports = {
     'indentation': 2,
     'string-quotes': 'single',
     'selector-max-id': 0,
+    'selector-max-type': 0,
+    'selector-max-universal': 0,
     'selector-list-comma-newline-after': 'always',
     'rule-empty-line-before': [
       'always',


### PR DESCRIPTION
Запрещаем универсальные селекторы и селекторы по типу.
Они могут нарушать инкапсуляцию

https://stylelint.io/user-guide/rules/selector-max-type/
https://stylelint.io/user-guide/rules/selector-max-universal/