### PR TITLE
Fix typo in the logical shorthands plugin name

### DIFF
--- a/index.js
+++ b/index.js
@@ -56,6 +56,6 @@ module.exports = {
       'ignoreCustomProperties': /.*/,
     },
     'plugin/vkui': true,
-    'plugin/stylelint-logical-shorthands': null,
+    'plugin/logical-shorthands': null,
   },
 };


### PR DESCRIPTION
related: https://github.com/VKCOM/VKUI/pull/6061

Из-за ошибки в имени плагина в VKUI репозитории появляются ошибки stylelint при обновлении на версию 3.5.1
ошибки в CI: https://github.com/VKCOM/VKUI/actions/runs/6688788013/job/18171327234?pr=6061

<img width="836" alt="Снимок экрана 2023-10-30 в 14 56 01" src="https://github.com/VKCOM/stylelint-config/assets/5443359/36551a68-b28d-4d4c-a41d-e109b42e5704">

Имя плагина заданное в исходниках:
https://github.com/VKCOM/stylelint-config/blob/1c656ed87d94c968b01941b8bae39eadbf0015e9/src/stylelint-logical-shorthands/index.ts#L201
