### PR TITLE
fix: ignore custom properties for `length-zero-no-unit` rule

### DIFF
--- a/index.js
+++ b/index.js
@@ -40,7 +40,9 @@ module.exports = {
     'no-duplicate-selectors': true,
     'color-named': 'never',
     'function-url-scheme-disallowed-list': ['/^data:/'],
-    'length-zero-no-unit': true,
+    'length-zero-no-unit': [true, {
+      ignore: ['custom-properties'],
+    }],
     'property-disallowed-list': [/^\./, 'letter-spacing'],
     'selector-pseudo-class-disallowed-list': ['root'],
     'declaration-block-semicolon-newline-after': 'always',


### PR DESCRIPTION
Для calc вычислений нужно явно указывать единицу измерения значения

<img width="441" alt="Снимок экрана 2023-11-22 в 15 25 20" src="https://github.com/VKCOM/stylelint-config/assets/42776347/ed5b6f90-8f51-4937-b83d-4eef25a3cf11">
