### PR TITLE
feat: rm stylelint-declaration-strict-value

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,13 +5,13 @@
 ## Установка
 
 ```sh
-yarn add -D @vkontakte/stylelint-config stylelint stylelint-declaration-strict-value postcss
+yarn add -D @vkontakte/stylelint-config stylelint postcss
 ```
 
 или
 
 ```sh
-npm install -D @vkontakte/stylelint-config stylelint stylelint-declaration-strict-value postcss
+npm install -D @vkontakte/stylelint-config stylelint postcss
 ```
 
 ## Использование

--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 module.exports = {
-  plugins: ["stylelint-declaration-strict-value", "./dist/stylelint-selector-bem-pattern", "./dist/stylelint-vkui", "./dist/stylelint-logical-shorthands"],
+  plugins: ["./dist/stylelint-selector-bem-pattern", "./dist/stylelint-vkui", "./dist/stylelint-logical-shorthands"],
   rules: {
     "max-nesting-depth": [0, { ignoreAtRules: ["supports"] }],
     indentation: 2,

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "postcss": "^8.4.16",
     "shx": "^0.3.4",
     "stylelint": "^16.1.0",
-    "stylelint-declaration-strict-value": "^1.9.2",
     "typescript": "^5.0.2"
   },
   "dependencies": {
@@ -35,7 +34,6 @@
   },
   "peerDependencies": {
     "postcss": "^8.4.16",
-    "stylelint": "^15.11.0 || ^16.1.0",
-    "stylelint-declaration-strict-value": "^1.9.2"
+    "stylelint": "^15.11.0 || ^16.1.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1188,20 +1188,10 @@ cross-spawn@^7.0.0, cross-spawn@^7.0.1, cross-spawn@^7.0.3:
     shebang-command "^2.0.0"
     which "^2.0.1"
 
-css-color-names@0.0.4:
-  version "0.0.4"
-  resolved "https://registry.yarnpkg.com/css-color-names/-/css-color-names-0.0.4.tgz#808adc2e79cf84738069b646cb20ec27beb629e0"
-  integrity sha1-gIrcLnnPhHOAabZGyyDsJ762KeA=
-
 css-functions-list@^3.2.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/css-functions-list/-/css-functions-list-3.2.1.tgz#2eb205d8ce9f9ce74c5c1d7490b66b77c45ce3ea"
   integrity sha512-Nj5YcaGgBtuUmn1D7oHqPW0c9iui7xsTsj5lIX8ZgevdfhmjFfKB3r8moHJtNJnctnYXJyYX5I1pp90HM4TPgQ==
-
-css-shorthand-properties@^1.0.0:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/css-shorthand-properties/-/css-shorthand-properties-1.1.1.tgz#1c808e63553c283f289f2dd56fcee8f3337bd935"
-  integrity sha512-Md+Juc7M3uOdbAFwOYlTrccIZ7oCFuzrhKYQjdeUEW/sE1hv17Jp/Bws+ReOPpGVBTYCBoYo+G17V5Qo8QQ75A==
 
 css-tree@^2.3.1:
   version "2.3.1"
@@ -1210,15 +1200,6 @@ css-tree@^2.3.1:
   dependencies:
     mdn-data "2.0.30"
     source-map-js "^1.0.1"
-
-css-values@^0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/css-values/-/css-values-0.1.0.tgz#128b7ce103d4dc027a814a5d5995c54781d7b4c6"
-  integrity sha1-Eot84QPU3AJ6gUpdWZXFR4HXtMY=
-  dependencies:
-    css-color-names "0.0.4"
-    ends-with "^0.2.0"
-    postcss-value-parser "^3.3.0"
 
 cssesc@^3.0.0:
   version "3.0.0"
@@ -1283,11 +1264,6 @@ emoji-regex@^9.2.2:
   version "9.2.2"
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-9.2.2.tgz#840c8803b0d8047f4ff0cf963176b32d4ef3ed72"
   integrity sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==
-
-ends-with@^0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/ends-with/-/ends-with-0.2.0.tgz#2f9da98d57a50cfda4571ce4339000500f4e6b8a"
-  integrity sha1-L52pjVelDP2kVxzkM5AAUA9Oa4o=
 
 env-paths@^2.2.1:
   version "2.2.1"
@@ -2453,11 +2429,6 @@ postcss-selector-parser@^6.0.13:
     cssesc "^3.0.0"
     util-deprecate "^1.0.2"
 
-postcss-value-parser@^3.3.0:
-  version "3.3.1"
-  resolved "https://registry.yarnpkg.com/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz#9ff822547e2893213cf1c30efa51ac5fd1ba8281"
-  integrity sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==
-
 postcss-value-parser@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz#723c09920836ba6d3e5af019f92bc0971c02e514"
@@ -2609,13 +2580,6 @@ shelljs@^0.8.5:
     interpret "^1.0.0"
     rechoir "^0.6.2"
 
-shortcss@^0.1.3:
-  version "0.1.3"
-  resolved "https://registry.yarnpkg.com/shortcss/-/shortcss-0.1.3.tgz#ee2a7904d80b7f5502c98408f4a2f313faadfb48"
-  integrity sha1-7ip5BNgLf1UCyYQI9KLzE/qt+0g=
-  dependencies:
-    css-shorthand-properties "^1.0.0"
-
 shx@^0.3.4:
   version "0.3.4"
   resolved "https://registry.yarnpkg.com/shx/-/shx-0.3.4.tgz#74289230b4b663979167f94e1935901406e40f02"
@@ -2737,14 +2701,6 @@ strip-json-comments@^3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-3.1.1.tgz#31f1281b3832630434831c310c01cccda8cbe006"
   integrity sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==
-
-stylelint-declaration-strict-value@^1.9.2:
-  version "1.9.2"
-  resolved "https://registry.yarnpkg.com/stylelint-declaration-strict-value/-/stylelint-declaration-strict-value-1.9.2.tgz#f2a884c669974a73f82c9f24b05beb81bc337480"
-  integrity sha512-Z/2yr7g4tq2iGOUWhZLzHL2g2GJYJGcPkfjDh++zI8ukLxW0tcLGJjo64XYCDjja6YcECPDUWbpN+OAoAtAYvw==
-  dependencies:
-    css-values "^0.1.0"
-    shortcss "^0.1.3"
 
 stylelint@^16.1.0:
   version "16.1.0"


### PR DESCRIPTION
Плагин, оказывается, уже давно не нужен.

К тому же, он ещё не поддерживает **Stylelint v16** [AndyOGo/stylelint-declaration-strict-value#327](https://togithub.com/AndyOGo/stylelint-declaration-strict-value/issues/327).

- caused by https://github.com/VKCOM/stylelint-config/pull/6