### PR TITLE
fix(refactor): complete migrate to stylelint v16

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,8 +1,7 @@
-module.exports = {
+export default {
   plugins: ["./dist/stylelint-selector-bem-pattern", "./dist/stylelint-vkui", "./dist/stylelint-logical-shorthands"],
   rules: {
     "max-nesting-depth": [0, { ignoreAtRules: ["supports"] }],
-    indentation: 2,
     "selector-max-id": 0,
     "selector-max-type": 0,
     "selector-max-universal": 0,

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,9 +1,15 @@
-module.exports = {
-  preset: "jest-preset-stylelint",
+import fs from 'node:fs';
+import process from 'node:process';
+
+export default {
+  preset: 'jest-preset-stylelint',
   transform: {
-    "^.+\\.(t|j)sx?$": "@swc/jest",
+    '^.+\\.(t|j)sx?$': '@swc/jest',
   },
-  testEnvironment: "node",
+  testEnvironment: 'node',
   // см. https://jestjs.io/ru/docs/ecmascript-modules
-  extensionsToTreatAsEsm: [".ts"],
+  extensionsToTreatAsEsm: ['.ts'],
+  moduleNameMapper: {
+    '^(\\.{1,2}/.*)\\.js$': '$1',
+  },
 };

--- a/package.json
+++ b/package.json
@@ -2,7 +2,9 @@
   "name": "@vkontakte/stylelint-config",
   "version": "4.0.1",
   "description": "stylelint config from VK",
+  "type": "module",
   "main": "index.js",
+  "exports": "./index.js",
   "engines": {
     "node": ">=20",
     "yarn": "^1.21.1"

--- a/src/stylelint-logical-shorthands/index.ts
+++ b/src/stylelint-logical-shorthands/index.ts
@@ -1,23 +1,19 @@
-import stylelint, { Rule } from "stylelint";
-import valueParser from "postcss-value-parser";
-import postcss from "postcss";
-import {
-  messageReportBorder,
-  messageReportBorderRadius,
-  messageReportSimple,
-} from "./messageReport";
+import stylelint, { Rule } from 'stylelint';
+import valueParser from 'postcss-value-parser';
+import postcss from 'postcss';
+import { messageReportBorder, messageReportBorderRadius, messageReportSimple } from './messageReport.js';
 
 function ignoreCommentAndSpaceNodes(valueNode: valueParser.Node): boolean {
-  return valueNode.type !== "comment" && valueNode.type !== "space";
+  return valueNode.type !== 'comment' && valueNode.type !== 'space';
 }
 
 /**
  * Собирает сообщение в зависимости от свойства
  */
 export function messageReport(prop: string) {
-  if (prop === "border-radius") {
+  if (prop === 'border-radius') {
     return messageReportBorderRadius(prop);
-  } else if (prop.startsWith("border")) {
+  } else if (prop.startsWith('border')) {
     return messageReportBorder(prop);
   }
 
@@ -33,8 +29,8 @@ export function messageReport(prop: string) {
  * ```
  */
 function logicalProp(prop: string, type: string) {
-  if (prop.startsWith("border")) {
-    return prop.replace("-", `-${type}-`);
+  if (prop.startsWith('border')) {
+    return prop.replace('-', `-${type}-`);
   }
 
   return `${prop}-${type}`;
@@ -44,8 +40,8 @@ function logicalProp(prop: string, type: string) {
  * Превращает свойства из физических в логические
  */
 function fixSimple(node: postcss.Declaration, valueNodes: valueParser.Node[]) {
-  let blockValue = "";
-  let inlineValue = "";
+  let blockValue = '';
+  let inlineValue = '';
 
   switch (valueNodes.length) {
     case 2:
@@ -53,33 +49,24 @@ function fixSimple(node: postcss.Declaration, valueNodes: valueParser.Node[]) {
       inlineValue = valueParser.stringify(valueNodes[1]);
       break;
     case 3:
-      blockValue =
-        valueParser.stringify(valueNodes[0]) +
-        " " +
-        valueParser.stringify(valueNodes[2]);
+      blockValue = valueParser.stringify(valueNodes[0]) + ' ' + valueParser.stringify(valueNodes[2]);
       inlineValue = valueParser.stringify(valueNodes[1]);
       break;
     case 4:
-      blockValue =
-        valueParser.stringify(valueNodes[0]) +
-        " " +
-        valueParser.stringify(valueNodes[2]);
-      inlineValue =
-        valueParser.stringify(valueNodes[3]) +
-        " " +
-        valueParser.stringify(valueNodes[1]);
+      blockValue = valueParser.stringify(valueNodes[0]) + ' ' + valueParser.stringify(valueNodes[2]);
+      inlineValue = valueParser.stringify(valueNodes[3]) + ' ' + valueParser.stringify(valueNodes[1]);
       break;
     default:
       return;
   }
 
   node.after({
-    prop: logicalProp(node.prop, "inline"),
+    prop: logicalProp(node.prop, 'inline'),
     value: inlineValue,
     important: node.important,
   });
   node.after({
-    prop: logicalProp(node.prop, "block"),
+    prop: logicalProp(node.prop, 'block'),
     value: blockValue,
     important: node.important,
   });
@@ -89,49 +76,44 @@ function fixSimple(node: postcss.Declaration, valueNodes: valueParser.Node[]) {
 /**
  * Превращает свойства из физических в логические для border radius
  */
-function fixBorderRadius(
-  node: postcss.Declaration,
-  valueNodes: valueParser.Node[]
-) {
-  let startStartValue = "";
-  let startEndValue = "";
-  let endEndValue = "";
-  let endStartValue = "";
+function fixBorderRadius(node: postcss.Declaration, valueNodes: valueParser.Node[]) {
+  let startStartValue = '';
+  let startEndValue = '';
+  let endEndValue = '';
+  let endStartValue = '';
 
-  let firstStartStartValue = "";
-  let firstStartEndValue = "";
-  let firstEndEndValue = "";
-  let firstEndStartValue = "";
+  let firstStartStartValue = '';
+  let firstStartEndValue = '';
+  let firstEndEndValue = '';
+  let firstEndStartValue = '';
 
-  const indexDiv = valueNodes.findIndex(
-    (valueNode) => valueNode.type === "div"
-  );
+  const indexDiv = valueNodes.findIndex(valueNode => valueNode.type === 'div');
 
   switch (indexDiv) {
     case 1:
-      const v = valueParser.stringify(valueNodes[0]) + " ";
+      const v = valueParser.stringify(valueNodes[0]) + ' ';
       firstStartStartValue = v;
       firstStartEndValue = v;
       firstEndEndValue = v;
       firstEndStartValue = v;
       break;
     case 2:
-      firstStartStartValue = valueParser.stringify(valueNodes[0]) + " ";
-      firstStartEndValue = valueParser.stringify(valueNodes[1]) + " ";
-      firstEndEndValue = valueParser.stringify(valueNodes[0]) + " ";
-      firstEndStartValue = valueParser.stringify(valueNodes[1]) + " ";
+      firstStartStartValue = valueParser.stringify(valueNodes[0]) + ' ';
+      firstStartEndValue = valueParser.stringify(valueNodes[1]) + ' ';
+      firstEndEndValue = valueParser.stringify(valueNodes[0]) + ' ';
+      firstEndStartValue = valueParser.stringify(valueNodes[1]) + ' ';
       break;
     case 3:
-      firstStartStartValue = valueParser.stringify(valueNodes[0]) + " ";
-      firstStartEndValue = valueParser.stringify(valueNodes[1]) + " ";
-      firstEndEndValue = valueParser.stringify(valueNodes[2]) + " ";
-      firstEndStartValue = valueParser.stringify(valueNodes[1]) + " ";
+      firstStartStartValue = valueParser.stringify(valueNodes[0]) + ' ';
+      firstStartEndValue = valueParser.stringify(valueNodes[1]) + ' ';
+      firstEndEndValue = valueParser.stringify(valueNodes[2]) + ' ';
+      firstEndStartValue = valueParser.stringify(valueNodes[1]) + ' ';
       break;
     case 4:
-      firstStartStartValue = valueParser.stringify(valueNodes[0]) + " ";
-      firstStartEndValue = valueParser.stringify(valueNodes[1]) + " ";
-      firstEndEndValue = valueParser.stringify(valueNodes[2]) + " ";
-      firstEndStartValue = valueParser.stringify(valueNodes[3]) + " ";
+      firstStartStartValue = valueParser.stringify(valueNodes[0]) + ' ';
+      firstStartEndValue = valueParser.stringify(valueNodes[1]) + ' ';
+      firstEndEndValue = valueParser.stringify(valueNodes[2]) + ' ';
+      firstEndStartValue = valueParser.stringify(valueNodes[3]) + ' ';
       break;
   }
 
@@ -164,22 +146,22 @@ function fixBorderRadius(
   }
 
   node.after({
-    prop: "border-end-start-radius",
+    prop: 'border-end-start-radius',
     value: firstEndStartValue + endStartValue,
     important: node.important,
   });
   node.after({
-    prop: "border-end-end-radius",
+    prop: 'border-end-end-radius',
     value: firstEndEndValue + endEndValue,
     important: node.important,
   });
   node.after({
-    prop: "border-start-end-radius",
+    prop: 'border-start-end-radius',
     value: firstStartEndValue + startEndValue,
     important: node.important,
   });
   node.after({
-    prop: "border-start-start-radius",
+    prop: 'border-start-start-radius',
     value: firstStartStartValue + startStartValue,
     important: node.important,
   });
@@ -190,7 +172,7 @@ function fixBorderRadius(
  * Превращает свойства из физических в логические
  */
 function fix(node: postcss.Declaration, valueNodes: valueParser.Node[]) {
-  if (node.prop === "border-radius") {
+  if (node.prop === 'border-radius') {
     fixBorderRadius(node, valueNodes);
     return;
   }
@@ -198,17 +180,17 @@ function fix(node: postcss.Declaration, valueNodes: valueParser.Node[]) {
   fixSimple(node, valueNodes);
 }
 
-export const ruleName = "plugin/logical-shorthands";
+export const ruleName = 'plugin/logical-shorthands';
 const messages = stylelint.utils.ruleMessages(ruleName, {});
 const meta = {
-  url: "https://github.com/VKCOM/stylelint-config/tree/master/src/stylelint-logical-shorthands",
+  url: 'https://github.com/VKCOM/stylelint-config/tree/master/src/stylelint-logical-shorthands',
 };
 
 const ruleFunction: Rule = (_, __, context) => {
   return (root, result) => {
     root.walkDecls(
       /^(inset|margin|padding|scroll-padding|scroll-margin|border-(width|style|color)|border-radius)$/,
-      (node) => {
+      node => {
         const parsedValue = valueParser(node.value);
         const valueNodes = parsedValue.nodes.filter(ignoreCommentAndSpaceNodes);
 

--- a/src/stylelint-logical-shorthands/stylelint-logical-shorthands.test.ts
+++ b/src/stylelint-logical-shorthands/stylelint-logical-shorthands.test.ts
@@ -1,7 +1,7 @@
-import { messageReport, ruleName } from "./index";
+import { messageReport, ruleName } from './index.js';
 
 testRule({
-  plugins: ["./src/stylelint-logical-shorthands/index.ts"],
+  plugins: ['./src/stylelint-logical-shorthands/index.ts'],
   ruleName,
   config: true,
   fix: true,
@@ -37,150 +37,150 @@ testRule({
     {
       code: `.class{inset: 1em 2em;}`,
       fixed: `.class{inset-block: 1em;inset-inline: 2em;}`,
-      message: messageReport("inset"),
+      message: messageReport('inset'),
     },
     {
       code: `.class{inset: 1em auto 2em;}`,
       fixed: `.class{inset-block: 1em 2em;inset-inline: auto;}`,
-      message: messageReport("inset"),
+      message: messageReport('inset'),
     },
     {
       code: `.class{inset: 2px 1em 0 auto;}`,
       fixed: `.class{inset-block: 2px 0;inset-inline: auto 1em;}`,
-      message: messageReport("inset"),
+      message: messageReport('inset'),
     },
     {
       code: `.class{margin: 1em 2em;}`,
       fixed: `.class{margin-block: 1em;margin-inline: 2em;}`,
-      message: messageReport("margin"),
+      message: messageReport('margin'),
     },
     {
       code: `.class{margin: 1em auto 2em;}`,
       fixed: `.class{margin-block: 1em 2em;margin-inline: auto;}`,
-      message: messageReport("margin"),
+      message: messageReport('margin'),
     },
     {
       code: `.class{margin: 2px 1em 0 auto;}`,
       fixed: `.class{margin-block: 2px 0;margin-inline: auto 1em;}`,
-      message: messageReport("margin"),
+      message: messageReport('margin'),
     },
     {
       code: `.class{padding: 1em 2em;}`,
       fixed: `.class{padding-block: 1em;padding-inline: 2em;}`,
-      message: messageReport("padding"),
+      message: messageReport('padding'),
     },
     {
       code: `.class{padding: 1em auto 2em;}`,
       fixed: `.class{padding-block: 1em 2em;padding-inline: auto;}`,
-      message: messageReport("padding"),
+      message: messageReport('padding'),
     },
     {
       code: `.class{padding: 2px 1em 0 auto;}`,
       fixed: `.class{padding-block: 2px 0;padding-inline: auto 1em;}`,
-      message: messageReport("padding"),
+      message: messageReport('padding'),
     },
 
     {
       code: `.class{scroll-padding: 1em 2em;}`,
       fixed: `.class{scroll-padding-block: 1em;scroll-padding-inline: 2em;}`,
-      message: messageReport("scroll-padding"),
+      message: messageReport('scroll-padding'),
     },
     {
       code: `.class{scroll-margin: 1em 2em;}`,
       fixed: `.class{scroll-margin-block: 1em;scroll-margin-inline: 2em;}`,
-      message: messageReport("scroll-margin"),
+      message: messageReport('scroll-margin'),
     },
 
     {
       code: `.class{inset: 1em 2em !important;}`,
       fixed: `.class{inset-block: 1em !important;inset-inline: 2em !important;}`,
-      message: messageReport("inset"),
+      message: messageReport('inset'),
     },
 
     // Border
     {
       code: `.class{border-width: 1em 2em;}`,
       fixed: `.class{border-block-width: 1em;border-inline-width: 2em;}`,
-      message: messageReport("border-width"),
+      message: messageReport('border-width'),
     },
     {
       code: `.class{border-width: 1em auto 2em;}`,
       fixed: `.class{border-block-width: 1em 2em;border-inline-width: auto;}`,
-      message: messageReport("border-width"),
+      message: messageReport('border-width'),
     },
     {
       code: `.class{border-width: 2px 1em 0 auto;}`,
       fixed: `.class{border-block-width: 2px 0;border-inline-width: auto 1em;}`,
-      message: messageReport("border-width"),
+      message: messageReport('border-width'),
     },
     {
       code: `.class{border-width: 1em 2em !important;}`,
       fixed: `.class{border-block-width: 1em !important;border-inline-width: 2em !important;}`,
-      message: messageReport("border-width"),
+      message: messageReport('border-width'),
     },
 
     {
       code: `.class{border-width: 1em 2em;}`,
       fixed: `.class{border-block-width: 1em;border-inline-width: 2em;}`,
-      message: messageReport("border-width"),
+      message: messageReport('border-width'),
     },
     {
       code: `.class{border-style: solid dash;}`,
       fixed: `.class{border-block-style: solid;border-inline-style: dash;}`,
-      message: messageReport("border-style"),
+      message: messageReport('border-style'),
     },
     {
       code: `.class{border-color: red blue;}`,
       fixed: `.class{border-block-color: red;border-inline-color: blue;}`,
-      message: messageReport("border-color"),
+      message: messageReport('border-color'),
     },
 
     // border-radius
     {
       code: `.class{border-radius: 1em 2em;}`,
       fixed: `.class{border-start-start-radius: 1em;border-start-end-radius: 2em;border-end-end-radius: 1em;border-end-start-radius: 2em;}`,
-      message: messageReport("border-radius"),
+      message: messageReport('border-radius'),
     },
     {
       code: `.class{border-radius: 1em 2em 3em;}`,
       fixed: `.class{border-start-start-radius: 1em;border-start-end-radius: 2em;border-end-end-radius: 3em;border-end-start-radius: 2em;}`,
-      message: messageReport("border-radius"),
+      message: messageReport('border-radius'),
     },
     {
       code: `.class{border-radius: 1em 2em 3em 4em;}`,
       fixed: `.class{border-start-start-radius: 1em;border-start-end-radius: 2em;border-end-end-radius: 3em;border-end-start-radius: 4em;}`,
-      message: messageReport("border-radius"),
+      message: messageReport('border-radius'),
     },
 
     {
       code: `.class{border-radius: 10% / 20%;}`,
       fixed: `.class{border-start-start-radius: 10% 20%;border-start-end-radius: 10% 20%;border-end-end-radius: 10% 20%;border-end-start-radius: 10% 20%;}`,
-      message: messageReport("border-radius"),
+      message: messageReport('border-radius'),
     },
     {
       code: `.class{border-radius: 10% 50% / 20%;}`,
       fixed: `.class{border-start-start-radius: 10% 20%;border-start-end-radius: 50% 20%;border-end-end-radius: 10% 20%;border-end-start-radius: 50% 20%;}`,
-      message: messageReport("border-radius"),
+      message: messageReport('border-radius'),
     },
     {
       code: `.class{border-radius: 10% 50% 25% / 20%;}`,
       fixed: `.class{border-start-start-radius: 10% 20%;border-start-end-radius: 50% 20%;border-end-end-radius: 25% 20%;border-end-start-radius: 50% 20%;}`,
-      message: messageReport("border-radius"),
+      message: messageReport('border-radius'),
     },
     {
       code: `.class{border-radius: 10% 50% 25% 75% / 20%;}`,
       fixed: `.class{border-start-start-radius: 10% 20%;border-start-end-radius: 50% 20%;border-end-end-radius: 25% 20%;border-end-start-radius: 75% 20%;}`,
-      message: messageReport("border-radius"),
+      message: messageReport('border-radius'),
     },
     {
       code: `.class{border-radius: 1em 2em 3em 4em / 5em 6em 7em 8em;}`,
       fixed: `.class{border-start-start-radius: 1em 5em;border-start-end-radius: 2em 6em;border-end-end-radius: 3em 7em;border-end-start-radius: 4em 8em;}`,
-      message: messageReport("border-radius"),
+      message: messageReport('border-radius'),
     },
     {
       code: `.class{border-radius: 1em 2em 3em 4em / 5em 6em 7em 8em !  important  ;}`,
       fixed: `.class{border-start-start-radius: 1em 5em !important;border-start-end-radius: 2em 6em !important;border-end-end-radius: 3em 7em !important;border-end-start-radius: 4em 8em !important;}`,
-      message: messageReport("border-radius"),
+      message: messageReport('border-radius'),
     },
   ],
 });

--- a/src/stylelint-selector-bem-pattern/index.ts
+++ b/src/stylelint-selector-bem-pattern/index.ts
@@ -1,6 +1,6 @@
 import stylelint, { Rule } from 'stylelint';
-import { process, BemOptions } from './process';
-import { isRegExp } from './lib/utils';
+import { process, BemOptions } from './process.js';
+import { isRegExp } from './lib/utils.js';
 
 function isString(object: any): boolean {
   return typeof object === 'string';
@@ -24,25 +24,37 @@ function isBoolean(object: any): boolean {
 
 const optionsSchema: any = {
   preset: ['suit', 'bem'],
-  presetOptions: function() { return true; },
-  componentName: [isStringOrRegExp],
-  componentSelectors: [(pattern: any) => {
-    if (isStringOrFunction(pattern)) return true;
-    if (!pattern.initial) return false;
-    if (!isStringOrFunction(pattern.initial)) return false;
-    if (pattern.combined && !isStringOrFunction(pattern.combined)) return false;
+  presetOptions: function () {
     return true;
-  }],
-  implicitComponents: [isBoolean, isString, function(pattern: any) {
-    return Array.isArray(pattern) && pattern.every(isString);
-  }],
-  implicitUtilities: [isBoolean, isString, function(pattern: any) {
-    return Array.isArray(pattern) && pattern.every(isString);
-  }],
+  },
+  componentName: [isStringOrRegExp],
+  componentSelectors: [
+    (pattern: any) => {
+      if (isStringOrFunction(pattern)) return true;
+      if (!pattern.initial) return false;
+      if (!isStringOrFunction(pattern.initial)) return false;
+      if (pattern.combined && !isStringOrFunction(pattern.combined)) return false;
+      return true;
+    },
+  ],
+  implicitComponents: [
+    isBoolean,
+    isString,
+    function (pattern: any) {
+      return Array.isArray(pattern) && pattern.every(isString);
+    },
+  ],
+  implicitUtilities: [
+    isBoolean,
+    isString,
+    function (pattern: any) {
+      return Array.isArray(pattern) && pattern.every(isString);
+    },
+  ],
   utilitySelectors: [isStringOrRegExp],
   ignoreSelectors: [
     isStringOrRegExp,
-    function(pattern: any) {
+    function (pattern: any) {
       if (!Array.isArray(pattern)) {
         return isStringOrRegExp(pattern);
       }
@@ -51,7 +63,7 @@ const optionsSchema: any = {
   ],
   ignoreCustomProperties: [
     isStringOrRegExp,
-    function(pattern: any) {
+    function (pattern: any) {
       if (!Array.isArray(pattern)) {
         return isStringOrRegExp(pattern);
       }
@@ -63,16 +75,12 @@ const optionsSchema: any = {
 export const ruleName = 'plugin/selector-bem-pattern';
 const messages = stylelint.utils.ruleMessages(ruleName, {});
 
-const ruleFunction: Rule<BemOptions> = (primaryOption) => {
+const ruleFunction: Rule<BemOptions> = primaryOption => {
   return (root, result) => {
-    const isValid = stylelint.utils.validateOptions(
-      result,
-      ruleName,
-      {
-        actual: primaryOption,
-        possible: optionsSchema,
-      }
-    );
+    const isValid = stylelint.utils.validateOptions(result, ruleName, {
+      actual: primaryOption,
+      possible: optionsSchema,
+    });
 
     if (!isValid) {
       return;
@@ -85,4 +93,4 @@ const ruleFunction: Rule<BemOptions> = (primaryOption) => {
 ruleFunction.ruleName = ruleName;
 ruleFunction.messages = messages;
 
-module.exports = stylelint.createPlugin(ruleName, ruleFunction);
+export default stylelint.createPlugin(ruleName, ruleFunction);

--- a/src/stylelint-selector-bem-pattern/lib/generate-config.ts
+++ b/src/stylelint-selector-bem-pattern/lib/generate-config.ts
@@ -1,5 +1,5 @@
-import { PresetOptions, presetPatterns } from './preset-patterns';
-import { SelectorPattern } from './validate-selectors';
+import { PresetOptions, presetPatterns } from './preset-patterns.js';
+import { SelectorPattern } from './validate-selectors.js';
 
 export interface BemOptions {
   preset?: 'bem' | 'suit';
@@ -18,13 +18,13 @@ export function generateConfig(primaryOptions: BemOptions) {
 
   const allPatterns = {
     ...patterns,
-    ...({
+    ...{
       utilitySelectors: primaryOptions.utilitySelectors,
       componentName: primaryOptions.componentName,
       componentSelectors: primaryOptions.componentSelectors,
       ignoreSelectors: primaryOptions.ignoreSelectors,
       ignoreCustomProperties: primaryOptions.ignoreCustomProperties,
-    }),
+    },
   };
 
   return {

--- a/src/stylelint-selector-bem-pattern/lib/get-selectors.ts
+++ b/src/stylelint-selector-bem-pattern/lib/get-selectors.ts
@@ -1,5 +1,5 @@
 import { Rule } from 'postcss';
-import { resolveNestedSelector } from './resolve-nested-selector';
+import { resolveNestedSelector } from './resolve-nested-selector.js';
 
 function isNestedRule(node: Rule): boolean {
   return node.parent ? /(?:at)?rule/.test(node.parent.type) : false;
@@ -18,11 +18,8 @@ function hasOnlyAllowedAtRules(node: Rule) {
   let containsNotAllowed = false;
 
   if (hasChildNodes(node)) {
-    node.each((child) => {
-      if (
-        child.type === 'atrule' &&
-        (child.name === 'extend' || child.name === 'media')
-      ) {
+    node.each(child => {
+      if (child.type === 'atrule' && (child.name === 'extend' || child.name === 'media')) {
         containsAllowed = true;
       } else if (child.type !== 'comment') {
         containsNotAllowed = true;

--- a/src/stylelint-selector-bem-pattern/lib/should-ignore-custom-property.ts
+++ b/src/stylelint-selector-bem-pattern/lib/should-ignore-custom-property.ts
@@ -1,14 +1,13 @@
 import { Declaration } from 'postcss';
-import { IGNORE_COMMENT } from './constants';
+import { IGNORE_COMMENT } from './constants.js';
 
-export function shouldIgnoreCustomProperty(customProperty: string, declaration: Declaration, patterns?: RegExp | RegExp[]) {
+export function shouldIgnoreCustomProperty(
+  customProperty: string,
+  declaration: Declaration,
+  patterns?: RegExp | RegExp[]
+) {
   const previousNode = declaration.prev();
-  if (
-    previousNode &&
-    previousNode.type === 'comment' &&
-    previousNode.text === IGNORE_COMMENT
-  )
-    return true;
+  if (previousNode && previousNode.type === 'comment' && previousNode.text === IGNORE_COMMENT) return true;
 
   if (!patterns) return false;
 

--- a/src/stylelint-selector-bem-pattern/lib/should-ignore-rule.ts
+++ b/src/stylelint-selector-bem-pattern/lib/should-ignore-rule.ts
@@ -1,11 +1,7 @@
 import { Rule } from 'postcss';
-import { IGNORE_COMMENT } from './constants';
+import { IGNORE_COMMENT } from './constants.js';
 
 export function shouldIgnoreRule(rule: Rule) {
   const previousNode = rule.prev();
-  return (
-    previousNode &&
-    previousNode.type === 'comment' &&
-    previousNode.text === IGNORE_COMMENT
-  );
+  return previousNode && previousNode.type === 'comment' && previousNode.text === IGNORE_COMMENT;
 }

--- a/src/stylelint-selector-bem-pattern/lib/validate-custom-properties.ts
+++ b/src/stylelint-selector-bem-pattern/lib/validate-custom-properties.ts
@@ -1,7 +1,7 @@
 import { Rule } from 'postcss';
-import { shouldIgnoreCustomProperty } from './should-ignore-custom-property';
+import { shouldIgnoreCustomProperty } from './should-ignore-custom-property.js';
 import stylelint, { PostcssResult } from 'stylelint';
-import { ruleName } from '../index';
+import { ruleName } from '../index.js';
 
 interface Config {
   rule: Rule;
@@ -16,8 +16,7 @@ export function validateCustomProperties(config: Config) {
 
     if (property.indexOf('--') !== 0) return;
 
-    if (shouldIgnoreCustomProperty(property, declaration, config.ignorePattern))
-      return;
+    if (shouldIgnoreCustomProperty(property, declaration, config.ignorePattern)) return;
 
     if (property.indexOf(`${config.componentName}-`) === 2) return;
 

--- a/src/stylelint-selector-bem-pattern/lib/validate-selectors.ts
+++ b/src/stylelint-selector-bem-pattern/lib/validate-selectors.ts
@@ -1,12 +1,12 @@
 import { Rule } from 'postcss';
-import { listSequences } from './list-sequences';
-import { shouldIgnoreRule } from './should-ignore-rule';
-import { shouldIgnoreSelector } from './should-ignore-selector';
-import { ComponentNameToRegexp, toInterpolatedRegexp } from './to-interpolated-regexp';
-import { getSelectors } from './get-selectors';
-import { isObject } from './utils';
+import { listSequences } from './list-sequences.js';
+import { shouldIgnoreRule } from './should-ignore-rule.js';
+import { shouldIgnoreSelector } from './should-ignore-selector.js';
+import { ComponentNameToRegexp, toInterpolatedRegexp } from './to-interpolated-regexp.js';
+import { getSelectors } from './get-selectors.js';
+import { isObject } from './utils.js';
 import stylelint, { PostcssResult } from 'stylelint';
-import { ruleName } from '../index';
+import { ruleName } from '../index.js';
 
 export interface SelectorPattern {
   initial: ComponentNameToRegexp;
@@ -27,17 +27,19 @@ export function validateSelectors(config: Config) {
   if (shouldIgnoreRule(config.rule)) return;
   const rule = config.rule;
 
-  const initialPattern = isObject(config.selectorPattern) &&'initial' in config.selectorPattern
-    ? toInterpolatedRegexp(config.selectorPattern.initial)(config.componentName)
-    : toInterpolatedRegexp(config.selectorPattern)(config.componentName);
+  const initialPattern =
+    isObject(config.selectorPattern) && 'initial' in config.selectorPattern
+      ? toInterpolatedRegexp(config.selectorPattern.initial)(config.componentName)
+      : toInterpolatedRegexp(config.selectorPattern)(config.componentName);
 
-  const combinedPattern = isObject(config.selectorPattern) && 'combined' in config.selectorPattern
-    ? toInterpolatedRegexp(config.selectorPattern.combined)(config.componentName)
-    : toInterpolatedRegexp(() => initialPattern)(config.componentName);
+  const combinedPattern =
+    isObject(config.selectorPattern) && 'combined' in config.selectorPattern
+      ? toInterpolatedRegexp(config.selectorPattern.combined)(config.componentName)
+      : toInterpolatedRegexp(() => initialPattern)(config.componentName);
 
   const selectors = getSelectors(rule);
 
-  selectors.forEach((selector) => {
+  selectors.forEach(selector => {
     // Don't bother with :root
     if (selector === ':root') return;
 
@@ -46,11 +48,7 @@ export function validateSelectors(config: Config) {
     for (let i = 0, l = allSequences.length; i < l; i++) {
       if (config.weakMode && i !== 0) return;
       sequence = allSequences[i];
-      if (
-        config.ignorePattern &&
-        shouldIgnoreSelector(sequence, config.ignorePattern)
-      )
-        continue;
+      if (config.ignorePattern && shouldIgnoreSelector(sequence, config.ignorePattern)) continue;
       if (i === 0 && initialPattern.test(sequence)) continue;
       if (i !== 0 && combinedPattern.test(sequence)) continue;
 

--- a/src/stylelint-selector-bem-pattern/lib/validate-utilities.ts
+++ b/src/stylelint-selector-bem-pattern/lib/validate-utilities.ts
@@ -1,10 +1,10 @@
-import { listSequences } from './list-sequences';
-import { shouldIgnoreRule } from './should-ignore-rule';
-import { shouldIgnoreSelector } from './should-ignore-selector';
-import { getSelectors } from './get-selectors';
+import { listSequences } from './list-sequences.js';
+import { shouldIgnoreRule } from './should-ignore-rule.js';
+import { shouldIgnoreSelector } from './should-ignore-selector.js';
+import { getSelectors } from './get-selectors.js';
 import { Rule } from 'postcss';
 import stylelint, { PostcssResult } from 'stylelint';
-import { ruleName } from '../index';
+import { ruleName } from '../index.js';
 
 interface Config {
   rule: Rule;
@@ -22,10 +22,7 @@ export function validateUtilities(config: Config) {
   selectors.forEach(selector => {
     const allSequences = listSequences(selector);
     for (const sequence of allSequences) {
-      if (
-        config.ignorePattern &&
-        shouldIgnoreSelector(sequence, config.ignorePattern)
-      ) {
+      if (config.ignorePattern && shouldIgnoreSelector(sequence, config.ignorePattern)) {
         continue;
       }
 

--- a/src/stylelint-selector-bem-pattern/process.ts
+++ b/src/stylelint-selector-bem-pattern/process.ts
@@ -1,13 +1,13 @@
 import path from 'path';
 import { AtRule, Root, Rule } from 'postcss';
-import { validateCustomProperties } from './lib/validate-custom-properties';
-import { validateUtilities } from './lib/validate-utilities';
-import { validateSelectors } from './lib/validate-selectors';
-import { BemOptions, generateConfig } from './lib/generate-config';
-import { toRegexp } from './lib/to-regexp';
-import { isImplicitComponent, isImplicitUtilities } from './lib/check-implicit';
+import { validateCustomProperties } from './lib/validate-custom-properties.js';
+import { validateUtilities } from './lib/validate-utilities.js';
+import { validateSelectors } from './lib/validate-selectors.js';
+import { BemOptions, generateConfig } from './lib/generate-config.js';
+import { toRegexp } from './lib/to-regexp.js';
+import { isImplicitComponent, isImplicitUtilities } from './lib/check-implicit.js';
 import stylelint, { PostcssResult } from 'stylelint';
-import { ruleName } from './index';
+import { ruleName } from './index.js';
 
 export { BemOptions };
 
@@ -15,9 +15,7 @@ const DEFINE_VALUE = '([-_a-zA-Z0-9]+)\\s*(?:;\\s*(weak))?';
 const DEFINE_DIRECTIVE = new RegExp(
   `(?:\\*?\\s*@define ${DEFINE_VALUE})|(?:\\s*postcss-bem-linter: define ${DEFINE_VALUE})\\s*`
 );
-const END_DIRECTIVE = new RegExp(
-  '(?:\\*\\s*@end\\s*)|' + '(?:\\s*postcss-bem-linter: end)\\s*'
-);
+const END_DIRECTIVE = new RegExp('(?:\\*\\s*@end\\s*)|' + '(?:\\s*postcss-bem-linter: end)\\s*');
 const UTILITIES_IDENT = 'utilities';
 const WEAK_IDENT = 'weak';
 
@@ -34,7 +32,7 @@ export function process(opts: BemOptions, root: Root, result: PostcssResult) {
     start: number;
     weakMode: boolean;
     end?: number;
-  }
+  };
 
   const ranges = findRanges(root);
 
@@ -59,10 +57,7 @@ export function process(opts: BemOptions, root: Root, result: PostcssResult) {
   function checkRule(rule: Rule, range: FileRange) {
     if (range.defined === UTILITIES_IDENT) {
       if (!patterns.utilitySelectors) {
-        throw new Error(
-          'You tried to `@define utilities` but have not provided ' +
-          'a `utilitySelectors` pattern'
-        );
+        throw new Error('You tried to `@define utilities` but have not provided ' + 'a `utilitySelectors` pattern');
       }
       validateUtilities({
         rule,
@@ -74,10 +69,7 @@ export function process(opts: BemOptions, root: Root, result: PostcssResult) {
     }
 
     if (!patterns.componentSelectors) {
-      throw new Error(
-        'You tried to `@define` a component but have not provided ' +
-        'a `componentSelectors` pattern'
-      );
+      throw new Error('You tried to `@define` a component but have not provided ' + 'a `componentSelectors` pattern');
     }
 
     validateCustomProperties({
@@ -109,17 +101,12 @@ export function process(opts: BemOptions, root: Root, result: PostcssResult) {
           weakMode: false,
         });
       } else if (isImplicitComponent(config.implicitComponents, filename)) {
-        let defined = stripUnderscore(
-          path.basename(filename).split('.')[0]
-        );
+        let defined = stripUnderscore(path.basename(filename).split('.')[0]);
         if (defined === 'index') {
           defined = path.basename(path.join(filename, '..'));
         }
 
-        if (
-          defined !== UTILITIES_IDENT &&
-          !toRegexp(config.componentNamePattern).test(defined)
-        ) {
+        if (defined !== UTILITIES_IDENT && !toRegexp(config.componentNamePattern).test(defined)) {
           stylelint.utils.report({
             ruleName,
             message: `Invalid component name from implicit conversion from filename ${filename}`,
@@ -137,9 +124,7 @@ export function process(opts: BemOptions, root: Root, result: PostcssResult) {
     }
 
     root.walkComments(comment => {
-      const commentStartLine = comment.source
-        ? comment.source?.start?.line
-        : null;
+      const commentStartLine = comment.source ? comment.source?.start?.line : null;
       if (!commentStartLine) return;
 
       if (END_DIRECTIVE.test(comment.text)) {
@@ -150,10 +135,7 @@ export function process(opts: BemOptions, root: Root, result: PostcssResult) {
       const directiveMatch = comment.text.match(DEFINE_DIRECTIVE);
       if (!directiveMatch) return;
       const defined = (directiveMatch[1] || directiveMatch[3]).trim();
-      if (
-        defined !== UTILITIES_IDENT &&
-        !toRegexp(config.componentNamePattern).test(defined)
-      ) {
+      if (defined !== UTILITIES_IDENT && !toRegexp(config.componentNamePattern).test(defined)) {
         stylelint.utils.report({
           ruleName,
           message: `Invalid component name in definition /*${comment}*/`,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,9 +1,8 @@
 {
   "compilerOptions": {
-    "module": "commonjs",
-    "target": "es2018",
-    "lib": ["es5", "es2015"],
-    "moduleResolution": "node",
+    "module": "NodeNext",
+    "target": "ESNext",
+    "moduleResolution": "NodeNext",
     "noImplicitAny": true,
     "removeComments": true,
     "preserveConstEnums": true,
@@ -15,12 +14,6 @@
     "outDir": "./dist",
     "skipLibCheck": true
   },
-  "include": [
-    "src/**/*.ts"
-  ],
-  "exclude": [
-    "node_modules",
-    "src/__tests__",
-    "**/*.test.ts"
-  ]
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "src/__tests__", "**/*.test.ts"]
 }


### PR DESCRIPTION
> [!NOTE]
>
> Поехало форматирование, т.к. в репе нет prettier конфига и всё форматировалось по настройкам моего IDE.
>
> В другом PR добавлю `.prettierrc`.

В PR #238 не до конца мигрировал конфиги. Это выяснилось при попытке починить линты в https://github.com/VKCOM/VKUI/pull/6606.

Поэтому по рекомендациям https://stylelint.io/migration-guide/to-16 делаем следующие изменения:

- добавляем в `package.json` поля `"type": "module"`, `"exports": "./index.js"` и `"module": "index.js"`;
- в `typescript.config.js` задаём `module` и `moduleResolution"  как `NodeNext`. ⚠️ после этого в `*.ts` относительных импортах используем расширение `.js`;
- заменяем `module.exports` на `exports default`;
- `jest.config.js` тоже переписываем в ESM, а также задаём `moduleNameMapper`, чтобы резолвились относительные импорты с `.js`;